### PR TITLE
Create one single instance that syncs data throughout the app

### DIFF
--- a/lib/BridgeState.dart
+++ b/lib/BridgeState.dart
@@ -1,18 +1,22 @@
 import 'package:flutter/foundation.dart';
 import 'package:huenicorn/hue/light.dart';
 import 'package:huenicorn/network/bridge_client.dart';
+import 'package:huenicorn/data//repository.dart';
 
 class BridgeState extends Object with ChangeNotifier {
+   Repository _repository;
 
   final BridgeClient _bridgeClient;
   List _lights;
 
   List get lights => _lights;
 
-  BridgeState(this._bridgeClient);
+  BridgeState(this._bridgeClient){
+    _repository = Repository.get();
+  }
 
   update() {
-    _bridgeClient.getLights()
+    _repository.getLights()
       .then((lights) {
         _lights = lights;
         notifyListeners();

--- a/lib/data/repository.dart
+++ b/lib/data/repository.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'package:huenicorn/Settings.dart';
+import 'package:huenicorn/network/light_deserializer.dart';
+import 'package:huenicorn/network/bridge_client.dart';
+
+
+class Repository {
+
+  BridgeClient _bridgeClient =  new BridgeClient(Settings.getInstance().bridgeAddress);
+
+  static final Repository _repo = new Repository._internal();
+
+  Repository._internal();
+
+  static Repository get() {
+    new BridgeClient(Settings.getInstance().bridgeAddress);
+    return _repo;
+  }
+
+  Future<List> getLights() async {
+
+    var json = await _bridgeClient.retrieveLights();
+    return (new LightDeserializer()).createLights(json);
+
+  }
+
+
+}

--- a/lib/network/bridge_client.dart
+++ b/lib/network/bridge_client.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 
 import 'package:huenicorn/hue/light.dart';
-import 'package:huenicorn/network/light_deserializer.dart';
+
 
 class BridgeClient {
   String bridgeAddress;
@@ -13,13 +13,12 @@ class BridgeClient {
 
   BridgeClient(this.bridgeAddress, [this.token = '0']);
 
-  Future<List> getLights() async {
+  Future<String> retrieveLights() async {
     var url = 'http://' + bridgeAddress + '/api/' + token + '/lights';
     var httpClient = new HttpClient();
     var request = await httpClient.getUrl(Uri.parse(url));
     var response = await request.close();
-    var json = await response.transform(utf8.decoder).join();
-    return (new LightDeserializer()).createLights(json);
+    return await response.transform(utf8.decoder).join();
   }
 
   setLight(Light light) async {

--- a/test_integration/bridge_client_test.dart
+++ b/test_integration/bridge_client_test.dart
@@ -1,16 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:huenicorn/data/repository.dart';
 import 'package:huenicorn/network/bridge_client.dart';
 
 void main() {
   test('Getting lights', () async {
-    var bridge = new BridgeClient('localhost');
-    var lights = await bridge.getLights();
+    var repository = Repository.get();
+    var lights = await repository.getLights();
     expect(lights.length, 10);
   });
 
   test('Settings lights', () async {
     var bridge = new BridgeClient('localhost');
-    var lights = await bridge.getLights();
+    var repository = Repository.get();
+    var lights = await repository.getLights();
     lights[0].brightness = 7.0;
     lights[0].hue = 32.0;
     await bridge.setLight(lights[0]);


### PR DESCRIPTION
the lights are fetched through the repository that is a single ton and holds all the data
in this case we really do want a singleton since only one instance should  sync the data else we get out of sync on each widget

TODO:
- find a way to fix integration test (maybe mock settings object)
- do same for set lights